### PR TITLE
Implemented PhpUnitDecorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea/
+/vendor/
+composer.lock

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Throwable Diagnostic PHPUnit Component
+
+Utilities for testing software using [ThrowableDiagnosticComponent](https://github.com/neighborhoods/ThrowableDiagnosticComponent).
+
+* Prevent diagnosis of failed assertions
+* Mocks for commonly injected classes
+
+## Install
+
+Via Composer as development dependency
+```bash
+composer require --dev neighborhoods/throwable-diagnostic-phpunit-component
+```
+
+## PHPUnit Decorator
+
+Failed [PHPUnit](https://github.com/sebastianbergmann/phpunit) assertions raise Exceptions. Throwable Diagnostic Component disturbs the Exception based communication between a test case and the PHPUnit framework. The [PHPUnit decorator](src/ThrowableDiagnosticV1Decorators/PhpUnitV1/README.md) prevents Throwable Diagnostic Component from interfering with PHPUnit Exceptions.
+
+## Mocks
+
+TBD

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,31 @@
+{
+    "name": "neighborhoods/throwable-diagnostic-phpunit-component",
+    "description": "Utilities for testing software using ThrowableDiagnosticComponent.",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Hrvoje Jukic",
+            "email": "hrcajuka@gmail.com"
+        }
+    ],
+    "keywords": [
+        "phpunit",
+        "throwable-diagnostic-component",
+        "testing"
+    ],
+    "minimum-stability": "stable",
+    "require": {
+        "neighborhoods/throwable-diagnostic-component": "^4.0.3"
+    },
+    "autoload": {
+        "psr-4": {
+            "Neighborhoods\\ThrowableDiagnosticPHPUnitComponent\\": [
+                "src"
+            ]
+        }
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/src/ThrowableDiagnosticV1Decorators/PhpUnitV1/PhpUnitDecorator.php
+++ b/src/ThrowableDiagnosticV1Decorators/PhpUnitV1/PhpUnitDecorator.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\ThrowableDiagnosticPHPUnitComponent\ThrowableDiagnosticV1Decorators\PhpUnitV1;
+
+use Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnosticV1\ThrowableDiagnosticInterface;
+use Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnosticV1\ThrowableDiagnostic;
+use Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnosticV1\ThrowableDiagnostic\DecoratorInterface;
+use Throwable;
+
+final class PhpUnitDecorator implements DecoratorInterface
+{
+    use ThrowableDiagnostic\AwareTrait;
+
+    public function diagnose(Throwable $throwable): ThrowableDiagnosticInterface
+    {
+        // Preserve PHPUnit exceptions.
+        // Check namespace to determine if an exception is a PHPUnit exception.
+        if (strpos(get_class($throwable), 'PHPUnit\\') === 0) {
+            throw $throwable;
+        }
+
+        $this->getThrowableDiagnosticV1ThrowableDiagnostic()->diagnose($throwable);
+
+        return $this;
+    }
+}

--- a/src/ThrowableDiagnosticV1Decorators/PhpUnitV1/PhpUnitDecorator.service.yml
+++ b/src/ThrowableDiagnosticV1Decorators/PhpUnitV1/PhpUnitDecorator.service.yml
@@ -1,0 +1,6 @@
+services:
+  Neighborhoods\ThrowableDiagnosticPHPUnitComponent\ThrowableDiagnosticV1Decorators\PhpUnitV1\PhpUnitDecorator:
+    class: Neighborhoods\ThrowableDiagnosticPHPUnitComponent\ThrowableDiagnosticV1Decorators\PhpUnitV1\PhpUnitDecorator
+    decorates: Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnosticV1\ThrowableDiagnosticInterface
+    calls:
+      - [setThrowableDiagnosticV1ThrowableDiagnostic, ['@Neighborhoods\ThrowableDiagnosticComponentTest\ThrowableDiagnosticV1Decorators\PhpUnitV1\PhpUnitDecorator.inner']]

--- a/src/ThrowableDiagnosticV1Decorators/PhpUnitV1/README.md
+++ b/src/ThrowableDiagnosticV1Decorators/PhpUnitV1/README.md
@@ -1,0 +1,18 @@
+# PHPUnit V1
+This Throwable Diagnostic Decorator helps integrate with [PHPUnit](https://github.com/sebastianbergmann/phpunit).
+
+An exception is thrown when a PHPUnit assertion fails. If this decorator is not part of the decorator stack, the PHPUnit exception will be diagnosed as non-transient causing the test case to error instead of failing. The error message doesn't include the assertion message, which makes it harder to understand and fix the problem.
+
+This implementation should work with any PHPUnit version.
+
+## Paths
+Unlike other decorators this is applied to the core of ThrowableDiagnostic using Symfony DI. This decorator will be added to all existing decorator stacks by including the path of this decorator in the container builder. Therefore, this path should only be added in the test container.
+
+```php
+$testContainerBuilder
+    // Your test container should already include the fab and src folders of ThrowableDiagnosticV1
+    ->addSourcePath('vendor/neighborhoods/throwable-diagnostic-component/fab/ThrowableDiagnosticV1')
+    ->addSourcePath('vendor/neighborhoods/throwable-diagnostic-component/src/ThrowableDiagnosticV1')
+    // This will add PhpUnitV1 to all existing decorator stacks
+    ->addSourcePath('vendor/neighborhoods/throwable-diagnostic-phpunit-component/src/ThrowableDiagnosticV1Decorators/PhpUnitV1');
+```


### PR DESCRIPTION
Instead of spending hours looking through the various PHPUnit versions and its Exception hierarchy I figured we could just look at the exception's namespace.
This should allow usage with any PHPUnit version. In fact since we don't use any PHPUnit classes in our code there's no need to list phpunit as a dependency.